### PR TITLE
Allow self-hosted instances to be used

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ SWIFTYPE_HOST_IDENTIFIER=
 
 Get your keys from the [Swiftype Credentials](https://app.swiftype.com/as#/credentials) page.
 
+When self-hosting an instance of AppSearch, you can use the API Endpoint displayed on the credentials page as 
+`SWIFTYPE_HOST_IDENTIFIER`, e.g.:
+
+```
+SWIFTYPE_HOST_IDENTIFIER=http://localhost:3002
+```
 
 ### API
 

--- a/src/Clients/Api.php
+++ b/src/Clients/Api.php
@@ -25,7 +25,14 @@ class Api extends \Elastic\AppSearch\Client\Client
             }
         }
 
-        $apiEndpoint = 'https://'.config('swiftype.host_identifier').'.api.swiftype.com/api/as/v1/';
+        $hostIdentifier = config('swiftype.host_identifier');
+
+        if (preg_match('/^https?:\/\//i', $hostIdentifier) === 1) {
+            $apiEndpoint = $hostIdentifier.'/api/as/v1/';
+        }
+        else {
+            $apiEndpoint = 'https://'.$hostIdentifier.'.api.swiftype.com/api/as/v1/';
+        }
         $apiKey = config('swiftype.api_private_key');
         $clientBuilder = ClientBuilder::create($apiEndpoint, $apiKey);
 

--- a/src/Clients/Api.php
+++ b/src/Clients/Api.php
@@ -29,8 +29,7 @@ class Api extends \Elastic\AppSearch\Client\Client
 
         if (preg_match('/^https?:\/\//i', $hostIdentifier) === 1) {
             $apiEndpoint = $hostIdentifier.'/api/as/v1/';
-        }
-        else {
+        } else {
             $apiEndpoint = 'https://'.$hostIdentifier.'.api.swiftype.com/api/as/v1/';
         }
         $apiKey = config('swiftype.api_private_key');


### PR DESCRIPTION
I wanted to use this package in my development environment, where I run a local instance of AppSearch in Docker. 

To be able to use it with custom endpoints, I changed the initialization of the Api Client. I'm not sure if this is the best way to do it, but I couldn't think of a cleaner way without creating breaking changes or using ugly if-statements in `config/swiftype.php`...